### PR TITLE
FB-2602: handle mongo v2 indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ this to resume interrupted tailers so that no information is lost.
 
 ## Version history
 
+### 1.1
+
+Allow both v1 and v2 indexes when handling index creation ops.
+
+### 1.0
+
+Fix persistent tailers read state approach.
+
+### 0.7
+
+Fix outlet method nomenclature to keep compatibility with pre-existing API.
+
 ### 0.6
 
 Fork and move to Yesware. Correct Mongo 2.0 collection method naming.

--- a/lib/mongoriver/log.rb
+++ b/lib/mongoriver/log.rb
@@ -1,7 +1,7 @@
 module Mongoriver
   module Logging
     def log
-      @@logger ||= Log4r::Logger.new("Stripe::Mongoriver", Log4r::ALL)
+      @@logger ||= Log4r::Logger.new("Stripe::Mongoriver")
     end
   end
 end

--- a/lib/mongoriver/log.rb
+++ b/lib/mongoriver/log.rb
@@ -1,7 +1,7 @@
 module Mongoriver
   module Logging
     def log
-      @@logger ||= Log4r::Logger.new("Stripe::Mongoriver")
+      @@logger ||= Log4r::Logger.new("Stripe::Mongoriver", Log4r::ALL)
     end
   end
 end

--- a/lib/mongoriver/stream.rb
+++ b/lib/mongoriver/stream.rb
@@ -95,6 +95,7 @@ module Mongoriver
 
     def handle_insert(db_name, collection_name, data)
       if collection_name == 'system.indexes'
+        log.info("INDEX CREATE: DB=#{db_name}, COLLECTION=#{collection_name}, DATA=#{data.inspect}")
         handle_create_index(data)
       else
         trigger(:insert, db_name, collection_name, data)

--- a/lib/mongoriver/stream.rb
+++ b/lib/mongoriver/stream.rb
@@ -95,7 +95,7 @@ module Mongoriver
 
     def handle_insert(db_name, collection_name, data)
       if collection_name == 'system.indexes'
-        log.warn("INDEX CREATE: DB=#{db_name}, COLLECTION=#{collection_name}, DATA=#{data.inspect}")
+        puts "INDEX CREATE: DB=#{db_name}, COLLECTION=#{collection_name}, DATA=#{data.inspect}"
         handle_create_index(data)
       else
         trigger(:insert, db_name, collection_name, data)

--- a/lib/mongoriver/stream.rb
+++ b/lib/mongoriver/stream.rb
@@ -95,7 +95,7 @@ module Mongoriver
 
     def handle_insert(db_name, collection_name, data)
       if collection_name == 'system.indexes'
-        log.info("INDEX CREATE: DB=#{db_name}, COLLECTION=#{collection_name}, DATA=#{data.inspect}")
+        log.warn("INDEX CREATE: DB=#{db_name}, COLLECTION=#{collection_name}, DATA=#{data.inspect}")
         handle_create_index(data)
       else
         trigger(:insert, db_name, collection_name, data)

--- a/lib/mongoriver/stream.rb
+++ b/lib/mongoriver/stream.rb
@@ -95,7 +95,6 @@ module Mongoriver
 
     def handle_insert(db_name, collection_name, data)
       if collection_name == 'system.indexes'
-        log.info("INDEX CREATE: DB=#{db_name}, COLLECTION=#{collection_name}, DATA=#{data.inspect}")
         handle_create_index(data)
       else
         trigger(:insert, db_name, collection_name, data)
@@ -116,10 +115,10 @@ module Mongoriver
       spec.each do |key, value|
         case key
         when 'v'
-          unless value == 1
-            raise NotImplementedError.new("Only v=1 indexes are supported, " \
-                                          "not v=#{value.inspect}: spec=" \
-                                          "#{spec.inspect}")
+          unless value == 1 || value == 2
+            raise NotImplementedError.new("Only v=1 or v=2 indexes are " \
+                                          "supported, not v=#{value.inspect}: " \
+                                          "spec=#{spec.inspect}")
           end
         when 'ns', 'key', '_id' # do nothing
         else

--- a/lib/mongoriver/stream.rb
+++ b/lib/mongoriver/stream.rb
@@ -95,7 +95,7 @@ module Mongoriver
 
     def handle_insert(db_name, collection_name, data)
       if collection_name == 'system.indexes'
-        puts "INDEX CREATE: DB=#{db_name}, COLLECTION=#{collection_name}, DATA=#{data.inspect}"
+        log.info("INDEX CREATE: DB=#{db_name}, COLLECTION=#{collection_name}, DATA=#{data.inspect}")
         handle_create_index(data)
       else
         trigger(:insert, db_name, collection_name, data)
@@ -118,7 +118,8 @@ module Mongoriver
         when 'v'
           unless value == 1
             raise NotImplementedError.new("Only v=1 indexes are supported, " \
-                                          "not v=#{value.inspect}")
+                                          "not v=#{value.inspect}: spec=" \
+                                          "#{spec.inspect}")
           end
         when 'ns', 'key', '_id' # do nothing
         else

--- a/lib/mongoriver/version.rb
+++ b/lib/mongoriver/version.rb
@@ -1,3 +1,3 @@
 module Mongoriver
-  VERSION = "1.0.2"
+  VERSION = "1.1.0"
 end

--- a/lib/mongoriver/version.rb
+++ b/lib/mongoriver/version.rb
@@ -1,3 +1,3 @@
 module Mongoriver
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/lib/mongoriver/version.rb
+++ b/lib/mongoriver/version.rb
@@ -1,3 +1,3 @@
 module Mongoriver
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
After upgrading the ProspectEvents cluster to 3.4, Mongoriver stopped working, dying with an error about indexes with a version != 1.  It looks like Mongo 3.4 adds a v2 index spec, and the upgrade process uses some of those indexes to look for things that are incompatible with 3.2 (as a downgrade guard?).

This pull allows us to handle v2 indexes just like we would have handled v1 indexes.  Note that for our use, we don't care about index creation (only data creation), but this should be a sane enough fix to push upstream.
