### PR TITLE
More mongoriver updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,26 +55,31 @@ this to resume interrupted tailers so that no information is lost.
 
 ## Version history
 
-### 1.1
+### 1.2.0
+
+Support `createIndexes` command (it's just another way of creating indexes),
+recognize but drop `collMod` commands.
+
+### 1.1.0
 
 Allow both v1 and v2 indexes when handling index creation ops.
 
-### 1.0
+### 1.0.0
 
 Fix persistent tailers read state approach.
 
-### 0.7
+### 0.7.0
 
 Fix outlet method nomenclature to keep compatibility with pre-existing API.
 
-### 0.6
+### 0.6.0
 
 Fork and move to Yesware. Correct Mongo 2.0 collection method naming.
 
-### 0.5
+### 0.5.0
 
 Move from the Moped driver to the native Mongo 2.0 driver.
 
-### 0.4
+### 0.4.0
 
 Add support for [tokumx](http://www.tokutek.com/products/tokumx-for-mongodb/). Backwards incompatible changes to persistent tailers to accomodate that. See [UPGRADING.md](UPGRADING.md).

--- a/lib/mongoriver/stream.rb
+++ b/lib/mongoriver/stream.rb
@@ -146,6 +146,8 @@ module Mongoriver
         trigger(:rename_collection, db_name, old_collection_name, new_collection_name)
       elsif data['dropDatabase'] == 1
         trigger(:drop_database, db_name)
+      elsif updated_collection = data['collMod']
+        log.warn('DROPPING collMod for collection "#{updated_collection}": #{data.inspect}')
       else
         raise "Unrecognized command #{data.inspect}"
       end

--- a/lib/mongoriver/stream.rb
+++ b/lib/mongoriver/stream.rb
@@ -102,7 +102,7 @@ module Mongoriver
     end
 
     def handle_create_index(spec)
-      db_name, collection_name = parse_ns(spec['ns'])
+      db_name, collection_name = parse_ns(spec['ns'] || spec['createIndexes'])
       index_key = spec['key'].map do |field, dir|
         if dir.is_a?(Numeric)
           [field, dir.round]
@@ -120,7 +120,7 @@ module Mongoriver
                                           "supported, not v=#{value.inspect}: " \
                                           "spec=#{spec.inspect}")
           end
-        when 'ns', 'key', '_id' # do nothing
+        when 'ns', 'key', '_id', 'createIndexes' # do nothing
         else
           options[key.to_sym] = value
         end
@@ -146,6 +146,8 @@ module Mongoriver
         trigger(:rename_collection, db_name, old_collection_name, new_collection_name)
       elsif data['dropDatabase'] == 1
         trigger(:drop_database, db_name)
+      elsif updated_collection = data['createIndexes']
+        handle_create_index(data)
       elsif updated_collection = data['collMod']
         log.warn('DROPPING collMod for collection "#{updated_collection}": #{data.inspect}')
       else

--- a/lib/mongoriver/version.rb
+++ b/lib/mongoriver/version.rb
@@ -1,3 +1,3 @@
 module Mongoriver
-  VERSION = "1.1.1"
+  VERSION = "1.2.0"
 end

--- a/lib/mongoriver/version.rb
+++ b/lib/mongoriver/version.rb
@@ -1,3 +1,3 @@
 module Mongoriver
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
Support `createIndexes` command (it's just another way of creating indexes),
recognize but drop `collMod` commands -- this would need another callback
in the `AbstractOutlet` interface, and we don't care about metadata updates
anyway.

This is enough to get the oplog watcher running again in staging.