### PR TITLE
FB-2740: allow oplog tailer to be shutdown cleanly

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,12 @@ mongo = Mongo::MongoClient.from_uri(mongo_uri)
 tailer = Mongoriver::Tailer.new([mongo], :existing)
 outlet = YourOutlet.new(your_params) # Your subclass of Mongoriver::AbstractOutlet here
 stream = Mongoriver::Stream.new(tailer, outlet)
+# install a shutdown handler so we can make sure to stop things cleanly
+trap('TERM') do
+  stream.stop
+end
 stream.run_forever(starting_timestamp)
+tailer.save_state
 ```
 
 `starting_timestamp` here is the time you want the tailer to start at. We use
@@ -54,6 +59,13 @@ this to resume interrupted tailers so that no information is lost.
 
 
 ## Version history
+
+### 1.2.1
+
+Allow the oplog cursor peek operation used by the tailer to be interrupted
+by adding a `max_time_ms` option to the query (which has the side effect of
+the wait for the next oplog item interruptible as well).  Also, handle the
+error this returns and turn it into a `false` return to wrap up the stream.
 
 ### 1.2.0
 

--- a/lib/mongoriver/version.rb
+++ b/lib/mongoriver/version.rb
@@ -1,3 +1,3 @@
 module Mongoriver
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
Before this fix, the lazy-enumerator `peek` used in the `Tailer#
cursor_has_more?` method would block and ignore SIGTERM signals,
causing the oplog tailer to chug on and then force Heroku to use
a SIGKILL to shut it down.  By blocking for potentially long times,
the save state interval was likely also not respected.

Now, the tailer adds a 1-second timeout on the cursor, which also
has the side effect of making the `peek` operation interruptable.