### PR TITLE
CAP-610: Ignore applyOps commands instead of throwing error

### DIFF
--- a/lib/mongoriver/stream.rb
+++ b/lib/mongoriver/stream.rb
@@ -150,6 +150,8 @@ module Mongoriver
         handle_create_index(data)
       elsif updated_collection = data['collMod']
         log.warn('DROPPING collMod for collection "#{updated_collection}": #{data.inspect}')
+      elsif data['applyOps']
+        log.info('Ignoring: #{data.inspect}')
       else
         raise "Unrecognized command #{data.inspect}"
       end

--- a/lib/mongoriver/version.rb
+++ b/lib/mongoriver/version.rb
@@ -1,3 +1,3 @@
 module Mongoriver
-  VERSION = "1.2.1"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
This pull fixes a command newly encountered on Atlas that causes an unexpected error.