### PR TITLE
KAT-427: Adjust configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ this to resume interrupted tailers so that no information is lost.
 
 ## Version history
 
-### 2.0.0
+### 1.3.0
 
-Pin mocha requirement to 1.X, seems to be the only version that works with the current Ruby version and libs
+Ignore `applyOps` command instead of throwing error.
 
 ### 1.2.1
 
@@ -98,4 +98,4 @@ Move from the Moped driver to the native Mongo 2.0 driver.
 
 ### 0.4.0
 
-Add support for [tokumx](http://www.tokutek.com/products/tokumx-for-mongodb/). Backwards incompatible changes to persistent tailers to accomodate that. See [UPGRADING.md](UPGRADING.md).
+Add support for [tokumx](http://www.tokutek.com/products/tokumx-for-mongodb/). Backwards incompatible changes to persistent tailers to accommodate that. See [UPGRADING.md](UPGRADING.md).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Mongoriver
-
+#
 mongoriver is a library to monitor updates to your Mongo databases in
 near-realtime. It provides a simple interface for you to take actions
 when records are inserted, removed, or updated.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Mongoriver
-#
+
 mongoriver is a library to monitor updates to your Mongo databases in
 near-realtime. It provides a simple interface for you to take actions
 when records are inserted, removed, or updated.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
   - id: 'bundle install'
-    name: gcr.io/repcore-prod/yw-ci:3.0.4
+    name: gcr.io/repcore-prod/yw-ci:3.0.4-4
     env:
     - 'RAILS_ENV=test'
     script: |
@@ -12,10 +12,9 @@ steps:
     - name: 'bundle'
       path: '/usr/local/bundle'
   - id: 'rake ci'
-    name: gcr.io/repcore-prod/yw-ci:3.0.4
+    name: gcr.io/repcore-prod/yw-ci:3.0.4-4
     env:
     - 'RAILS_ENV=test'
-    - 'CLOUDBUILD_PG=postgres-14-7'
     script: |
       #!/usr/bin/env bash
       source /nvm/nvmrc

--- a/lib/mongoriver/version.rb
+++ b/lib/mongoriver/version.rb
@@ -1,3 +1,3 @@
 module Mongoriver
-  VERSION = "2.0.0"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
Adjusts the configs introduced [here](https://github.com/vendasta/mongoriver/pull/8):
* Revert to version 1.3.0
* Set cloud build image to `3.0.4-4`
* Clean up readme