### PR TITLE
CTO-45: Add service-level.yaml

### DIFF
--- a/service-level.yaml
+++ b/service-level.yaml
@@ -1,0 +1,6 @@
+services:
+  - name: mongoriver
+    owner: honey-badger
+    language: ruby
+    nonServiceType: library
+    description: "A library for writing MongoDB oplog tailers."


### PR DESCRIPTION
Adds `service-level.yaml` declaring `honey-badger` ownership for this Yesware repo.

Part of CTO-45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)